### PR TITLE
Fix MESSENGER and RUINS interaction (issue #67)

### DIFF
--- a/src/model/card.test.ts
+++ b/src/model/card.test.ts
@@ -6333,7 +6333,7 @@ describe("Card", () => {
         expect(player.getPlayedCardInfos(CardName.MESSENGER).length).to.be(2);
       });
 
-      it("should  be relocated when attached to Crane and Crane is used", () => {
+      it("should be relocated when attached to Crane and Crane is used", () => {
         player.addToCity(gameState, CardName.CRANE);
         player.addToCity(gameState, CardName.MESSENGER);
         player.gainResources(gameState, { [ResourceType.TWIG]: 1 });
@@ -6490,6 +6490,46 @@ describe("Card", () => {
           cardOwnerId: player.playerId,
           usedForCritter: false,
           shareSpaceWith: CardName.MESSENGER,
+        });
+      });
+
+      it("should pair unpaired messengers with newly added constructions", () => {
+        player.addToCity(gameState, CardName.FARM);
+        player.addToCity(gameState, CardName.MESSENGER);
+        player.removeCardFromCity(
+          gameState,
+          player.getFirstPlayedCard(CardName.FARM)
+        );
+
+        player.addCardToHand(gameState, CardName.TWIG_BARGE);
+        player.gainResources(gameState, { TWIG: 1, PEBBLE: 1 });
+
+        [player, gameState] = multiStepGameInputTest(
+          gameState,
+          [playCardInput(CardName.TWIG_BARGE)],
+          { autoAdvance: true }
+        );
+
+        let playedMessengers = player.getPlayedCardInfos(CardName.MESSENGER);
+
+        expect(playedMessengers[0]).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.TWIG_BARGE,
+        });
+
+        expect(player.hasCardInCity(CardName.MESSENGER)).to.be(true);
+        expect(player.hasCardInCity(CardName.TWIG_BARGE)).to.be(true);
+        expect(player.getFirstPlayedCard(CardName.TWIG_BARGE)).to.eql({
+          cardName: CardName.TWIG_BARGE,
+          cardOwnerId: player.playerId,
+          usedForCritter: false,
+          shareSpaceWith: CardName.MESSENGER,
+        });
+        expect(player.getFirstPlayedCard(CardName.MESSENGER)).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.TWIG_BARGE,
         });
       });
     });

--- a/src/model/card.test.ts
+++ b/src/model/card.test.ts
@@ -5944,7 +5944,7 @@ describe("Card", () => {
         });
       });
 
-      it("should be relocated if Construction is destroyed", () => {
+      it("should remove from Construction if MESSENGER removed by UNIVERSITY", () => {
         player.addToCity(gameState, CardName.FARM);
         player.addToCity(gameState, CardName.MESSENGER);
         player.addToCity(gameState, CardName.UNIVERSITY);
@@ -6017,7 +6017,7 @@ describe("Card", () => {
         });
       });
 
-      it("should be relocated if Construction is destroyed via played RUINS", () => {
+      it("should be relocated to RUINS if Construction is destroyed via played RUINS", () => {
         player.addToCity(gameState, CardName.FARM);
         player.addToCity(gameState, CardName.MESSENGER);
 
@@ -6057,6 +6057,86 @@ describe("Card", () => {
           cardOwnerId: player.playerId,
           usedForCritter: false,
           shareSpaceWith: CardName.MESSENGER,
+        });
+      });
+
+      it("should be relocated to Player's chosen card if Construction is destroyed via played RUINS", () => {
+        player.addToCity(gameState, CardName.FARM);
+        player.addToCity(gameState, CardName.TWIG_BARGE);
+        player.addToCity(gameState, CardName.MESSENGER);
+
+        player.updatePlayedCard(
+          gameState,
+          player.getFirstPlayedCard(CardName.FARM),
+          { shareSpaceWith: CardName.MESSENGER }
+        );
+        player.updatePlayedCard(
+          gameState,
+          player.getFirstPlayedCard(CardName.MESSENGER),
+          { shareSpaceWith: CardName.FARM }
+        );
+        player.cardsInHand.push(CardName.RUINS);
+
+        expect(player.getFirstPlayedCard(CardName.MESSENGER)).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.FARM,
+        });
+
+        const selectPlayedCardInputRuins = {
+          inputType: GameInputType.SELECT_PLAYED_CARDS as const,
+          prevInputType: GameInputType.PLAY_CARD,
+          cardOptions: [
+            ...player.getPlayedCardInfos(CardName.FARM),
+            ...player.getPlayedCardInfos(CardName.TWIG_BARGE),
+          ],
+          cardContext: CardName.RUINS,
+          playedCardContext: undefined,
+          maxToSelect: 1,
+          minToSelect: 1,
+          clientOptions: {
+            selectedCards: [player.getFirstPlayedCard(CardName.FARM)],
+          },
+        };
+
+        const cardOwnerId = player.getPlayedCardInfos(CardName.MESSENGER);
+
+        // gameinput asking player to choose card
+        const selectPlayedCardInputMessenger = {
+          inputType: GameInputType.SELECT_PLAYED_CARDS as const,
+          prevInputType: GameInputType.PLAY_CARD,
+          cardContext: CardName.MESSENGER,
+          playedCardContext: {
+            cardOwnerId: cardOwnerId[0].cardOwnerId,
+            cardName: CardName.MESSENGER,
+            shareSpaceWith: undefined,
+          },
+          cardOptions: player.getPlayedCardInfos(CardName.TWIG_BARGE),
+          maxToSelect: 1,
+          minToSelect: 1,
+          clientOptions: {
+            selectedCards: [player.getFirstPlayedCard(CardName.TWIG_BARGE)],
+          },
+        };
+
+        [player, gameState] = multiStepGameInputTest(gameState, [
+          playCardInput(CardName.RUINS),
+          selectPlayedCardInputRuins,
+          selectPlayedCardInputMessenger,
+        ]);
+
+        expect(player.hasCardInCity(CardName.MESSENGER)).to.be(true);
+
+        expect(player.getFirstPlayedCard(CardName.MESSENGER)).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.TWIG_BARGE,
+        });
+        expect(player.hasCardInCity(CardName.RUINS)).to.be(true);
+        expect(player.getFirstPlayedCard(CardName.RUINS)).to.eql({
+          cardName: CardName.RUINS,
+          cardOwnerId: player.playerId,
+          usedForCritter: false,
         });
       });
 
@@ -6207,6 +6287,98 @@ describe("Card", () => {
         expect(gameState.getActivePlayer().playerId).to.not.eql(
           player.playerId
         );
+      });
+
+      // multiple messengers
+      it("should handle unpaired messengers and RUINS", () => {
+        player.addToCity(gameState, CardName.FARM);
+        player.addToCity(gameState, CardName.TWIG_BARGE);
+        player.addToCity(gameState, CardName.MESSENGER);
+        player.addToCity(gameState, CardName.MESSENGER);
+
+        let playedMessengers = player.getPlayedCardInfos(CardName.MESSENGER);
+        expect(player.getPlayedCardInfos(CardName.MESSENGER).length).to.be(2);
+
+        player.updatePlayedCard(
+          gameState,
+          player.getFirstPlayedCard(CardName.FARM),
+          { shareSpaceWith: CardName.MESSENGER }
+        );
+        player.updatePlayedCard(gameState, playedMessengers[0], {
+          shareSpaceWith: CardName.FARM,
+        });
+
+        player.updatePlayedCard(
+          gameState,
+          player.getFirstPlayedCard(CardName.TWIG_BARGE),
+          { shareSpaceWith: CardName.MESSENGER }
+        );
+        player.updatePlayedCard(gameState, playedMessengers[1], {
+          shareSpaceWith: CardName.TWIG_BARGE,
+        });
+
+        player.cardsInHand.push(CardName.RUINS);
+
+        playedMessengers = player.getPlayedCardInfos(CardName.MESSENGER);
+
+        expect(playedMessengers[0]).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.FARM,
+        });
+
+        expect(playedMessengers[1]).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.TWIG_BARGE,
+        });
+
+        const selectPlayedCardInputRuins = {
+          inputType: GameInputType.SELECT_PLAYED_CARDS as const,
+          prevInputType: GameInputType.PLAY_CARD,
+          cardOptions: [
+            ...player.getPlayedCardInfos(CardName.FARM),
+            ...player.getPlayedCardInfos(CardName.TWIG_BARGE),
+          ],
+          cardContext: CardName.RUINS,
+          playedCardContext: undefined,
+          maxToSelect: 1,
+          minToSelect: 1,
+          clientOptions: {
+            selectedCards: [player.getFirstPlayedCard(CardName.FARM)],
+          },
+        };
+
+        [player, gameState] = multiStepGameInputTest(gameState, [
+          playCardInput(CardName.RUINS),
+          selectPlayedCardInputRuins,
+        ]);
+
+        expect(player.hasCardInCity(CardName.MESSENGER)).to.be(true);
+
+        playedMessengers = player.getPlayedCardInfos(CardName.MESSENGER);
+        expect(playedMessengers.length).to.be(2);
+
+        // if we destroy one of the constructions, the messenger should stick to the RUINS
+        // because the other card already has a messenger on it
+        expect(playedMessengers[0]).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.RUINS,
+        });
+
+        expect(playedMessengers[1]).to.eql({
+          cardName: CardName.MESSENGER,
+          cardOwnerId: player.playerId,
+          shareSpaceWith: CardName.TWIG_BARGE,
+        });
+        expect(player.hasCardInCity(CardName.RUINS)).to.be(true);
+        expect(player.getFirstPlayedCard(CardName.RUINS)).to.eql({
+          cardName: CardName.RUINS,
+          cardOwnerId: player.playerId,
+          usedForCritter: false,
+          shareSpaceWith: CardName.MESSENGER,
+        });
       });
     });
 

--- a/src/model/card.test.ts
+++ b/src/model/card.test.ts
@@ -6510,7 +6510,7 @@ describe("Card", () => {
           { autoAdvance: true }
         );
 
-        let playedMessengers = player.getPlayedCardInfos(CardName.MESSENGER);
+        const playedMessengers = player.getPlayedCardInfos(CardName.MESSENGER);
 
         expect(playedMessengers[0]).to.eql({
           cardName: CardName.MESSENGER,

--- a/src/model/card.test.ts
+++ b/src/model/card.test.ts
@@ -6027,11 +6027,7 @@ describe("Card", () => {
         player.addToCity(gameState, CardName.FARM);
         player.addToCity(gameState, CardName.TWIG_BARGE);
         player.addToCity(gameState, CardName.MESSENGER);
-        player.addToCity(
-          gameState,
-          CardName.UNIVERSITY,
-          false /* shouldRelocateMessengers */
-        );
+        player.addToCity(gameState, CardName.UNIVERSITY);
 
         player.updatePlayedCard(
           gameState,
@@ -6065,26 +6061,23 @@ describe("Card", () => {
           shareSpaceWith: CardName.MESSENGER,
         });
 
-        const cardOwnerId = player.getPlayedCardInfos(CardName.MESSENGER)[0]
-          .cardOwnerId;
-
         // gameinput asking player to choose card
         const selectPlayedCardInputMessenger = {
           inputType: GameInputType.SELECT_PLAYED_CARDS as const,
           prevInputType: GameInputType.PLAY_CARD,
           cardContext: CardName.MESSENGER,
           playedCardContext: {
-            cardOwnerId: cardOwnerId,
+            cardOwnerId: player.playerId,
             cardName: CardName.MESSENGER,
             shareSpaceWith: undefined,
           },
           cardOptions: [
             ...player.getPlayedCardInfos(CardName.TWIG_BARGE),
             {
-              cardOwnerId: cardOwnerId,
+              cardOwnerId: player.playerId,
               cardName: CardName.UNIVERSITY,
               usedForCritter: false,
-              workers: [cardOwnerId],
+              workers: [player.playerId],
             },
           ],
           maxToSelect: 1,
@@ -6207,23 +6200,20 @@ describe("Card", () => {
           },
         };
 
-        const cardOwnerId = player.getPlayedCardInfos(CardName.MESSENGER)[0]
-          .cardOwnerId;
-
         // gameinput asking player to choose card
         const selectPlayedCardInputMessenger = {
           inputType: GameInputType.SELECT_PLAYED_CARDS as const,
           prevInputType: GameInputType.PLAY_CARD,
           cardContext: CardName.MESSENGER,
           playedCardContext: {
-            cardOwnerId: cardOwnerId,
+            cardOwnerId: player.playerId,
             cardName: CardName.MESSENGER,
             shareSpaceWith: undefined,
           },
           cardOptions: [
             ...player.getPlayedCardInfos(CardName.TWIG_BARGE),
             {
-              cardOwnerId: cardOwnerId,
+              cardOwnerId: player.playerId,
               cardName: CardName.RUINS,
               usedForCritter: false,
             },

--- a/src/model/card.ts
+++ b/src/model/card.ts
@@ -1199,7 +1199,11 @@ const CARD_REGISTRY: Record<CardName, Card> = {
         const selectedPlayer = gameState.getPlayer(
           gameInput.clientOptions.selectedPlayer
         );
-        selectedPlayer.addToCity(gameState, CardName.FOOL);
+        selectedPlayer.addToCity(
+          gameState,
+          CardName.FOOL,
+          true /* shouldRelocateMessengers */
+        );
         gameState.addGameLogFromCard(CardName.FOOL, [
           player,
           " added the ",
@@ -3825,7 +3829,8 @@ const CARD_REGISTRY: Record<CardName, Card> = {
 
         let newPlayedCard = targetPlayer.addToCity(
           gameState,
-          CardName.PIRATE_SHIP
+          CardName.PIRATE_SHIP,
+          true /* shouldRelocateMessengers */
         );
         newPlayedCard = targetPlayer.updatePlayedCard(
           gameState,

--- a/src/model/card.ts
+++ b/src/model/card.ts
@@ -2711,7 +2711,7 @@ const CARD_REGISTRY: Record<CardName, Card> = {
       { type: "em", text: "Common Critter" },
       " in your city.",
     ]),
-    // 1 point per common critter
+    // 1 point per common critterx
     pointsInner: getPointsPerRarityLabel({ isCritter: true, isUnique: false }),
   }),
   [CardName.SHEPHERD]: new Card({

--- a/src/model/card.ts
+++ b/src/model/card.ts
@@ -2683,25 +2683,31 @@ const CARD_REGISTRY: Record<CardName, Card> = {
           throw new Error("Cannot ruins non-construction");
         }
 
+        // keep track of whether we are re-activating a RUINS or
+        // playing a RUINS card
+        const playedRuinsCard = gameInput.playedCardContext;
+
         // don't relocate messengers until we've added RUINS to city
         player.removeCardFromCity(
           gameState,
           selectedCards[0],
           true /* addToDiscardPile */,
-          !!gameInput.playedCardContext /* shouldRelocateMessengers */
+          !!playedRuinsCard /* shouldRelocateMessengers */
         );
 
-        player.gainResources(gameState, targetCard.baseCost);
-        // This doesn't if we're reactiving a played RUINS
-        if (!gameInput.playedCardContext) {
-          // we should relocate any unpaired messengers
+        if (!playedRuinsCard) {
+          // we should relocate any unpaired messengers if we are
+          // adding RUINS to city
           player.addToCity(
             gameState,
             CardName.RUINS,
             true /* shouldRelocateMessengers */
           );
         }
+
+        player.gainResources(gameState, targetCard.baseCost);
         player.drawCards(gameState, 2);
+
         gameState.addGameLogFromCard(CardName.RUINS, [
           player,
           " ruined ",

--- a/src/model/card.ts
+++ b/src/model/card.ts
@@ -2711,7 +2711,7 @@ const CARD_REGISTRY: Record<CardName, Card> = {
       { type: "em", text: "Common Critter" },
       " in your city.",
     ]),
-    // 1 point per common critterx
+    // 1 point per common critter
     pointsInner: getPointsPerRarityLabel({ isCritter: true, isUnique: false }),
   }),
   [CardName.SHEPHERD]: new Card({

--- a/src/model/player.ts
+++ b/src/model/player.ts
@@ -272,12 +272,12 @@ export class Player implements IGameTextEntity {
           shareSpaceWith: undefined,
         });
       } else {
-        const sharedMesenger = (
-          this.playedCards[CardName.MESSENGER] || []
-        ).find(({ shareSpaceWith }) => {
-          return shareSpaceWith === playedCardInfo.cardName;
-        });
-        if (!sharedMesenger) {
+        let sharedMessenger = (this.playedCards[CardName.MESSENGER] || []).find(
+          ({ shareSpaceWith }) => {
+            return shareSpaceWith === playedCardInfo.cardName;
+          }
+        );
+        if (!sharedMessenger) {
           throw new Error(
             "Couldn't find the Messenger shared by the Construction."
           );
@@ -290,9 +290,13 @@ export class Player implements IGameTextEntity {
         if (cardOptions.length === 0) {
           // NOTE: Messenger stays in the city!
           // See: https://boardgamegeek.com/thread/2261133/article/32762766#32762766
-          player.updatePlayedCard(gameState, sharedMesenger, {
-            shareSpaceWith: undefined,
-          });
+          sharedMessenger = player.updatePlayedCard(
+            gameState,
+            sharedMessenger,
+            {
+              shareSpaceWith: undefined,
+            }
+          );
           gameState.addGameLogFromCard(CardName.MESSENGER, [
             Card.fromName(CardName.MESSENGER),
             " doesn't have a Construction to share a space with. ",
@@ -302,19 +306,13 @@ export class Player implements IGameTextEntity {
           gameState.addGameLogFromCard(CardName.MESSENGER, [
             "Needs a new space.",
           ]);
-          player.updatePlayedCard(gameState, sharedMesenger, {
-            shareSpaceWith: undefined,
-          });
-
-          // find first messenger that doesn't share a space with a construction
-          // I think this is a safe assumption because we just need to
-          // reassign 1 messenger and it doesn't matter which one
-
-          const newMessenger = (
-            this.playedCards[CardName.MESSENGER] || []
-          ).find(({ shareSpaceWith }) => {
-            return shareSpaceWith === undefined;
-          });
+          sharedMessenger = player.updatePlayedCard(
+            gameState,
+            sharedMessenger,
+            {
+              shareSpaceWith: undefined,
+            }
+          );
 
           gameState.pendingGameInputs.push({
             inputType: GameInputType.SELECT_PLAYED_CARDS,
@@ -322,7 +320,7 @@ export class Player implements IGameTextEntity {
             label: "Select a new Construction to share a space with",
             cardOptions,
             cardContext: CardName.MESSENGER,
-            playedCardContext: newMessenger,
+            playedCardContext: sharedMessenger,
             maxToSelect: 1,
             minToSelect: 1,
             clientOptions: {

--- a/src/model/player.ts
+++ b/src/model/player.ts
@@ -307,8 +307,8 @@ export class Player implements IGameTextEntity {
           });
 
           // find first messenger that doesn't share a space with a construction
-          // I think this is a safe assumption because we just need to reassign 1 messenger,
-          // doesn't matter which one
+          // I think this is a safe assumption because we just need to
+          // reassign 1 messenger and it doesn't matter which one
 
           const newMessenger = (
             this.playedCards[CardName.MESSENGER] || []


### PR DESCRIPTION
2 issues with our existing MESSENGER implementation:

- (1) When removing a Construction from the city, we look to see if it has a MESSENGER that shares a space with it. We updated the played card to say that the MESSENGER doesn't share a space with that Construction anymore, but we pass the const sharedMesenger (sic) instead of passing the updated card info
- (2) When a Construction is played, we check to see if there are any unpaired messengers. If there are, we pair it to the newly played Construction. However, when a RUINS is played, if there are other eligible constructions to choose from, we want to give the player the option to choose which Construction to pair the MESSENGER with (vs. automatically pairing it with the RUINS)